### PR TITLE
Bundle patched pydicom offline; make wheel versions single-source

### DIFF
--- a/scripts/download-pyodide.sh
+++ b/scripts/download-pyodide.sh
@@ -132,9 +132,11 @@ PYTHON_SCRIPT
 echo ""
 echo "⬇️  Downloading PyPI wheels for packages not in Pyodide..."
 
-# These are pure Python packages that work with micropip
+# These are pure Python packages that work with micropip.
+# pydicom is pinned to the patched release (>=2.4.5 fixes GHSA-v856-2rf8-9f28,
+# a DICOMDIR path traversal) and stays <3 to match dicompare's own constraint.
 PYPI_WHEELS=(
-    "pydicom==2.4.4"
+    "pydicom==2.4.5"
     "tabulate"
     "nibabel"
     "dicompare==$DICOMPARE_VERSION"
@@ -149,6 +151,26 @@ for pkg in "${PYPI_WHEELS[@]}"; do
     pip download --no-deps -d "$DEST_DIR/wheels" "$pkg" 2>/dev/null || \
     echo "   Warning: Could not download $pkg"
 done
+
+# Record exactly which wheels were bundled so the worker installs these rather
+# than a hardcoded list that can drift out of sync with what we downloaded.
+# This manifest is the single source of truth for the offline install list.
+# dicompare is ordered last so its dependencies are already present when it
+# installs (micropip cannot fetch missing deps offline).
+echo ""
+echo "🧾 Writing offline wheel manifest..."
+python3 - "$DEST_DIR/wheels" << 'PYTHON_SCRIPT'
+import json, os, sys
+wheels_dir = sys.argv[1]
+names = [f for f in os.listdir(wheels_dir) if f.endswith(".whl")]
+names.sort(key=lambda n: (n.startswith("dicompare-"), n.lower()))
+with open(os.path.join(wheels_dir, "manifest.json"), "w") as f:
+    json.dump(names, f, indent=2)
+    f.write("\n")
+print(f"   Wrote manifest.json with {len(names)} wheels:")
+for n in names:
+    print(f"     - {n}")
+PYTHON_SCRIPT
 
 echo ""
 echo "📋 Downloaded Pyodide core files:"

--- a/src/workers/pyodide.worker.ts
+++ b/src/workers/pyodide.worker.ts
@@ -142,46 +142,38 @@ async function initializePyodide(requestId?: string): Promise<{ pyodideVersion: 
     console.log('[Worker] Pyodide packages loaded from local storage');
   }
 
-  // Determine package source based on environment
-  let packageSource: string;
   const wheelBase = getWheelBaseUrl();
-  if (inElectronProd) {
-    // In Electron production, install from bundled wheel with absolute path
-    packageSource = wheelBase + `dicompare-${DICOMPARE_VERSION}-py3-none-any.whl`;
-    console.log('[Worker] Installing dicompare from bundled wheel...');
-    console.log('[Worker] Wheel base URL:', wheelBase);
-  } else {
-    // Detect development vs production using Vite's build mode
-    // Note: Don't use hostname detection as localhost is used in production containers too
-    const isDevelopment = import.meta.env?.MODE === 'development';
-    packageSource = isDevelopment
-      ? `http://localhost:3001/pyodide/wheels/dicompare-${DICOMPARE_VERSION}-py3-none-any.whl`
-      : `dicompare==${DICOMPARE_VERSION}`;
-    console.log(`[Worker] Installing dicompare from ${isDevelopment ? 'local dev server' : 'PyPI'}...`);
-  }
-
   reportProgress('Loading DICOM analysis tools...', 60);
 
-  // For Electron production, we need to install dependencies from bundled wheels too
-  const installCode = inElectronProd ? `
+  let installCode: string;
+  if (inElectronProd) {
+    // Offline install. The bundled wheels — and their exact versions — are the
+    // single source of truth in scripts/download-pyodide.sh, which records them
+    // in wheels/manifest.json. Install exactly what was bundled (deps first,
+    // dicompare last) instead of hardcoding versions here that could drift out
+    // of sync with what the download script actually fetched.
+    console.log('[Worker] Installing dicompare from bundled wheels...');
+    console.log('[Worker] Wheel base URL:', wheelBase);
+    const manifestResp = await fetch(wheelBase + 'manifest.json');
+    if (!manifestResp.ok) {
+      throw new Error(
+        `Could not load bundled wheel manifest (HTTP ${manifestResp.status}) from ${wheelBase}manifest.json`
+      );
+    }
+    const bundledWheels: string[] = await manifestResp.json();
+    installCode = `
 import micropip
 
-# Install bundled wheels for offline use with absolute file:// URLs
+# Install bundled wheels for offline use with absolute file:// URLs.
 wheel_base = '${wheelBase}'
-wheels_to_install = [
-    wheel_base + 'pydicom-2.4.4-py3-none-any.whl',
-    wheel_base + 'tabulate-0.9.0-py3-none-any.whl',
-    wheel_base + 'nibabel-5.3.3-py3-none-any.whl',
-    wheel_base + 'twixtools-0.24-py3-none-any.whl',
-    '${packageSource}',
-]
+wheels_to_install = ${JSON.stringify(bundledWheels)}
 
-for wheel in wheels_to_install:
+for name in wheels_to_install:
     try:
-        await micropip.install(wheel)
-        print(f"[Worker] Installed {wheel}")
+        await micropip.install(wheel_base + name)
+        print(f"[Worker] Installed {name}")
     except Exception as e:
-        print(f"[Worker] Warning: Could not install {wheel}: {e}")
+        print(f"[Worker] Warning: Could not install {name}: {e}")
 
 import dicompare
 import dicompare.interface
@@ -192,7 +184,16 @@ import json
 from typing import List, Dict, Any
 
 print("[Worker] dicompare modules imported successfully")
-` : `
+`;
+  } else {
+    // Detect development vs production using Vite's build mode.
+    // Note: Don't use hostname detection as localhost is used in production containers too.
+    const isDevelopment = import.meta.env?.MODE === 'development';
+    const packageSource = isDevelopment
+      ? `http://localhost:3001/pyodide/wheels/dicompare-${DICOMPARE_VERSION}-py3-none-any.whl`
+      : `dicompare==${DICOMPARE_VERSION}`;
+    console.log(`[Worker] Installing dicompare from ${isDevelopment ? 'local dev server' : 'PyPI'}...`);
+    installCode = `
 import micropip
 await micropip.install('${packageSource}')
 
@@ -206,6 +207,7 @@ from typing import List, Dict, Any
 
 print("[Worker] dicompare modules imported successfully")
 `;
+  }
 
   await pyodide.runPythonAsync(installCode);
 


### PR DESCRIPTION
The Electron offline bundle shipped pydicom 2.4.4, which is vulnerable to GHSA-v856-2rf8-9f28 (DICOMDIR path traversal), and would also fail to install once dicompare requires pydicom>=2.4.5 (no PyPI fallback offline). Bump the bundled wheel to pydicom 2.4.5.

While here, remove the duplicated wheel-version list. Previously the versions were hardcoded in two places — download-pyodide.sh (what we fetch) and the worker's wheels_to_install (exact filenames to install) — which silently break if they drift apart. Now download-pyodide.sh writes wheels/manifest.json recording exactly what it downloaded (dicompare ordered last so its deps resolve offline), and the worker installs whatever the manifest lists. The download script is the single source of truth; the worker hardcodes no versions.