### PR TITLE
Bump bundled dicompare to 0.7.0

### DIFF
--- a/public/embed/dicompare-worker.js
+++ b/public/embed/dicompare-worker.js
@@ -12,7 +12,7 @@
 
 const PYODIDE_CDN = 'https://cdn.jsdelivr.net/pyodide/v0.27.0/full/';
 // Version updated automatically by the version-bump GitHub Action on release
-const DICOMPARE_PACKAGE = 'dicompare==0.6.0';
+const DICOMPARE_PACKAGE = 'dicompare==0.7.0';
 
 let pyodide = null;
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,4 +3,4 @@
 export const VERSION = '0.11.2';
 
 // dicompare pip package version
-export const DICOMPARE_VERSION = '0.6.0';
+export const DICOMPARE_VERSION = '0.7.0';


### PR DESCRIPTION
## Summary
Points the web app at the freshly published **dicompare 0.7.0** (now live on PyPI).

- `src/version.ts`: `DICOMPARE_VERSION` `0.6.0` → `0.7.0`. This is the single source of truth for the production PyPI install, the dev-server wheel path, and the Electron offline bundle — `scripts/download-pyodide.sh` reads it and already pins the matching `pydicom==2.4.5` (dicompare 0.7.0 requires `pydicom>=2.4.5`).
- `public/embed/dicompare-worker.js`: standalone embed worker carries its own hardcoded constant → `0.7.0`.

## What's in dicompare 0.7.0
- Siemens `.pro`/`.exar1` extraction fixes (field strength, physio/TOF/flow-comp false positives, inversion time, multi-echo series expansion)
- pydicom bumped past the path-traversal advisory (GHSA-v856-2rf8-9f28); dropped EOL Python 3.8/3.9
- Test coverage raised to 98% with a 90% release gate

## Testing
`tsc --noEmit` passes. No other source references to the old version remain (historical wheels under `public/pyodide/wheels/` are regenerated at build time by the download script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)